### PR TITLE
Feature/comment creation

### DIFF
--- a/app/admin/feedback_sessions.rb
+++ b/app/admin/feedback_sessions.rb
@@ -1,0 +1,2 @@
+ActiveAdmin.register FeedbackSession do
+end

--- a/app/admin/session_comments.rb
+++ b/app/admin/session_comments.rb
@@ -1,0 +1,2 @@
+ActiveAdmin.register SessionComment do
+end

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -4,6 +4,8 @@ class FeedbackSession < ApplicationRecord
   has_many :session_tags, dependent: :destroy
   has_many :tags, through: :session_tags
 
+  has_many :session_comments, dependent: :destroy
+
   scope :for_user, ->(user) { where(provider: user).or(where(receiver: user)) }
 
   validates :session_date, presence: true

--- a/app/models/session_comment.rb
+++ b/app/models/session_comment.rb
@@ -1,0 +1,24 @@
+class SessionComment < ApplicationRecord
+  belongs_to :feedback_session, class_name: 'FeedbackSession'
+
+  validates :body, presence: true
+end
+
+# == Schema Information
+#
+# Table name: session_comments
+#
+#  id                  :bigint(8)        not null, primary key
+#  body                :text
+#  feedback_session_id :bigint(8)        not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_session_comments_on_feedback_session_id  (feedback_session_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (feedback_session_id => feedback_sessions.id)
+#

--- a/db/migrate/20230822181632_create_session_comments.rb
+++ b/db/migrate/20230822181632_create_session_comments.rb
@@ -1,0 +1,10 @@
+class CreateSessionComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :session_comments do |t|
+      t.text :body
+      t.references :feedback_session, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_22_145708) do
+ActiveRecord::Schema.define(version: 2023_08_22_181632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,14 @@ ActiveRecord::Schema.define(version: 2023_08_22_145708) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "session_comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "feedback_session_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["feedback_session_id"], name: "index_session_comments_on_feedback_session_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -83,4 +91,5 @@ ActiveRecord::Schema.define(version: 2023_08_22_145708) do
   add_foreign_key "feedback_sessions", "users", column: "receiver_id"
   add_foreign_key "session_tags", "feedback_sessions"
   add_foreign_key "session_tags", "tags"
+  add_foreign_key "session_comments", "feedback_sessions"
 end

--- a/lib/fake_data_loader.rb
+++ b/lib/fake_data_loader.rb
@@ -33,6 +33,7 @@ module FakeDataLoader
     load_admin
     load_users
     load_sessions
+    load_session_commments
   end
 
   def self.load_admin
@@ -62,6 +63,18 @@ module FakeDataLoader
           :feedback_session,
           provider: user,
           receiver: User.where.not(id: user.id).sample
+        )
+      end
+    end
+  end
+
+  def self.load_session_commments
+    FeedbackSession.all.each do |session|
+      rand(2..4).times do
+        create(
+          :session_comment,
+          feedback_session: session,
+          body: Faker::Lorem.paragraph
         )
       end
     end

--- a/spec/factories/session_comments.rb
+++ b/spec/factories/session_comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :session_comment do
+    body { "MyText" }
+    feedback_session
+  end
+end

--- a/spec/models/session_comment_spec.rb
+++ b/spec/models/session_comment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe SessionComment, type: :model do
+  it 'has a valid factory' do
+    expect(build(:session_comment)).to be_valid
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:body) }
+  end
+
+  describe 'Associations' do
+    subject(:session_comment) { build(:session_comment) }
+
+    it { expect(session_comment).to belong_to(:feedback_session) }
+  end
+end


### PR DESCRIPTION
### Contexto
​Se generaron modelos para poder crear nuevos comentarios en las sesiones de feedback. 
### Qué se esta haciendo
​Creación de modelo SessionComment.
Creación de relación entre FeedbackSession y SessionComment.
Adición de ambos modelos a la vista de ActiveAdmin.
Adición de la generación de comentarios mediante FakeDataLoader.
#### En particular hay que revisar
​Los modelos deben aparecer correctamente en la vista de ActiveAdmin.
Se deben generar los comentarios al correr `bin/rails db:setup`.

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
