### PR TITLE
Feature/comment visualization

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,7 +11,7 @@ import BaseTitle from './components/base-title.vue';
 import UserSession from './components/user-session.vue';
 import FeedbackSessions from './components/feedback-sessions.vue';
 import FeedbackSessionsNew from './components/feedback-sessions-new.vue';
-import FeedbackSession from './components/feedback-session.vue';
+import SessionComments from './components/session-comments.vue';
 import SessionComment from './components/session-comment.vue';
 import './css/application.css';
 
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       UserSession,
       FeedbackSessions,
       FeedbackSessionsNew,
-      FeedbackSession,
+      SessionComments,
       SessionComment,
     },
   });

--- a/app/javascript/components/feedback-sessions-item.vue
+++ b/app/javascript/components/feedback-sessions-item.vue
@@ -8,10 +8,16 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const sessionCommentsUrl = `/app/feedback_sessions/${props.session.id}/session_comments`;
+
 </script>
 
 <template>
   <div class="flex flex-row items-center gap-6 bg-white p-4 shadow">
+    <img
+      :src="require('images/icons/profile-picture.png')"
+      class="h-6 w-6 rounded-full border border-indigo-400"
+    >
     <span class="text-lg text-slate-800">
       {{ type === 'provider' ? props.session.receiver.name : props.session.provider.name }}
     </span>
@@ -25,11 +31,14 @@ const props = defineProps<Props>();
         {{ tag.name }}
       </span>
     </div>
-    <button class="ml-auto flex h-6 w-6 items-center justify-center rounded-full bg-slate-100">
+    <a
+      class="ml-auto flex h-6 w-6 items-center justify-center rounded-full bg-slate-100"
+      :href="sessionCommentsUrl"
+    >
       <inline-svg
         :src="require('images/icons/dots-vertical.svg')"
         class="h-4 w-4 fill-indigo-900"
       />
-    </button>
+    </a>
   </div>
 </template>

--- a/app/javascript/components/session-comment-item.vue
+++ b/app/javascript/components/session-comment-item.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { SessionComment } from 'api/session-comments';
+
+interface Props {
+  comment: SessionComment
+}
+
+const props = defineProps<Props>();
+
+</script>
+<template>
+  <div class="w-80 gap-3 rounded-md border-2 border-solid border-gray-200 bg-white p-3 shadow md:w-full md:max-w-3xl md:rounded-lg ">
+    <p class="font-base text-sm font-normal text-gray-700">
+      {{ props.comment.body }}
+    </p>
+  </div>
+</template>

--- a/app/javascript/components/session-comment.vue
+++ b/app/javascript/components/session-comment.vue
@@ -14,6 +14,7 @@ const props = defineProps<Props>();
 const formError = ref('');
 const loading = ref(false);
 const session = ref(props.initialSession);
+const backUrl = `/app/feedback_sessions/${session.value.id}/session_comments`;
 
 async function submitForm(comment: Omit<SessionComment, 'id'>) {
   try {
@@ -31,6 +32,9 @@ async function submitForm(comment: Omit<SessionComment, 'id'>) {
 </script>
 
 <template>
+  <back-button
+    :link-to="backUrl"
+  />
   <div class="flex flex-col justify-center ">
     <template v-if="session">
       <div class="inline-flex flex-col items-start gap-4 md:gap-7">

--- a/app/javascript/components/session-comments.vue
+++ b/app/javascript/components/session-comments.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { FeedbackSession } from 'api/feedback-sessions';
+import type { SessionComment } from 'api/session-comments';
+import FeedbackSessionInfo from './feedback-session-info.vue';
+import SessionCommentItem from './session-comment-item.vue';
+import BackButton from './back-button.vue';
+
+interface Props {
+  feedbackSession: FeedbackSession,
+  sessionComments: SessionComment[]
+}
+
+const props = defineProps<Props>();
+
+const newCommentUrl = `/app/feedback_sessions/${props.feedbackSession.id}/session_comments/new`;
+
+</script>
+
+<template>
+  <back-button />
+  <div class="flex flex-col justify-center ">
+    <template v-if="props.feedbackSession">
+      <div class="inline-flex flex-col items-start gap-4 md:gap-7">
+        <base-title class="font-base text-2xl font-normal text-gray-700 md:text-3xl">
+          Sesión de feedback #{{ props.feedbackSession.id }}
+        </base-title>
+        <feedback-session-info :session="props.feedbackSession" />
+      </div>
+      <div class="flex w-80 flex-col items-start gap-2 md:inline-flex md:w-auto md:max-w-3xl">
+        <div class="w-full items-center justify-between md:flex  md:max-w-3xl">
+          <p class="m-2 font-base text-xl font-normal text-gray-500">
+            Comentarios
+          </p>
+          <base-button
+            class="flex w-full items-center justify-center gap-2 rounded bg-indigo-500 p-2 md:w-auto"
+            :href="newCommentUrl"
+          >
+            <inline-svg
+              :src="require('images/icons/commment-icong.svg')"
+              class="h-4 w-4 shrink-0"
+            />
+            <p class=" text-center font-base text-sm font-semibold text-white">
+              Añadir comentario
+            </p>
+          </base-button>
+        </div>
+        <session-comment-item
+          v-for="comment in props.sessionComments"
+          :key="comment.id"
+          :comment="comment"
+        />
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/views/app/session_comments/index.html.erb
+++ b/app/views/app/session_comments/index.html.erb
@@ -1,0 +1,4 @@
+<session-comments
+  :feedback-session="<%= serialize_resource(@feedback_session) %>"
+  :session-comments="<%= serialize_resource(@session_comments)%>"
+></session-comments>


### PR DESCRIPTION
### Contexto
Actualmente en la sesiones de feedback solo se pueden generar los nuevos comentarios, pero estos aún no pueden ser visualizados.
### Qué se esta haciendo

Se agrega la vista para poder ver los comentarios.
Ahora se puede acceder desde vista de sesiones de feedback (feedback_session_item.vue) a los comentarios de una sesión de particular.
Se agregan botones de navegación para ir a la vista anterior. 
#### En particular hay que revisar
​Creación de componentes .vue y vista .erb

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)

Vista en escritorio
![image](https://github.com/platanus/fdbk1/assets/61152916/f524c766-64f3-407c-9156-f66023d16ad5)

Vista en mobile 
![image](https://github.com/platanus/fdbk1/assets/61152916/6158ee9f-aef4-4a61-acae-3b0abec5377d)

